### PR TITLE
Remove coroutines dependencies

### DIFF
--- a/purchasely/android/build.gradle
+++ b/purchasely/android/build.gradle
@@ -47,8 +47,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2'
 
     api 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.0'
 


### PR DESCRIPTION
We added it because it was not a transitive dependency with our android sdk before