### PR TITLE
fix(pubspec): bump min Dart SDK to 3.0.0 for nonNulls

### DIFF
--- a/purchasely/pubspec.yaml
+++ b/purchasely/pubspec.yaml
@@ -4,7 +4,7 @@ version: 5.7.3
 homepage: https://www.purchasely.com/
 
 environment:
-  sdk: ">=2.17.3 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
   flutter: ">=1.20.0"
 
 dependencies:

--- a/purchasely_android_player/pubspec.yaml
+++ b/purchasely_android_player/pubspec.yaml
@@ -4,7 +4,7 @@ version: 5.7.3
 homepage: https://www.purchasely.com/
 
 environment:
-  sdk: ">=2.17.3 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
   flutter: ">=2.5.0"
 
 dependencies:

--- a/purchasely_google/pubspec.yaml
+++ b/purchasely_google/pubspec.yaml
@@ -4,7 +4,7 @@ version: 5.7.3
 homepage: https://www.purchasely.com/
 
 environment:
-  sdk: ">=2.17.3 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
   flutter: ">=2.5.0"
 
 dependencies:


### PR DESCRIPTION
## Summary
The v5.7.3 publish workflow failed at `flutter pub publish --dry-run` with 4 `sdk_version_since` warnings: `lib/purchasely_flutter.dart` uses `Iterable.nonNulls` (Dart 3.0+, introduced in #88) while pubspecs allowed Dart `2.17.3`.

Bumps the min Dart SDK constraint to `>=3.0.0 <4.0.0` in all 3 packages so the v5.7.3 release can publish to pub.dev.

## Test plan
- [ ] CI green
- [ ] After merge, retag `v5.7.3` on the new HEAD to retrigger publish.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)