### PR TITLE
fix(ci): use dart-lang/setup-dart reusable workflow for OIDC publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,7 +98,8 @@ jobs:
     if: ${{ github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
     permissions:
       id-token: write
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+      contents: read
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
     with:
       environment: pub.dev
       working-directory: purchasely
@@ -107,6 +108,7 @@ jobs:
     name: Wait for pub.dev indexing
     runs-on: ubuntu-latest
     needs: [publish-purchasely]
+    if: ${{ github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
     steps:
       - run: sleep 30
 
@@ -115,7 +117,8 @@ jobs:
     needs: [wait-after-purchasely]
     permissions:
       id-token: write
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+      contents: read
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
     with:
       environment: pub.dev
       working-directory: purchasely_google
@@ -125,7 +128,8 @@ jobs:
     needs: [wait-after-purchasely]
     permissions:
       id-token: write
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+      contents: read
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
     with:
       environment: pub.dev
       working-directory: purchasely_android_player

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,84 +89,46 @@ jobs:
   # ============================================
   # Publish packages (sequentially, order matters)
   # ============================================
+  # Uses dart-lang/setup-dart reusable workflow which performs the OIDC
+  # token exchange with pub.dev automatically. The package admin must
+  # have configured "Automated publishing" on pub.dev for this to work.
   publish-purchasely:
     name: Publish purchasely_flutter
-    runs-on: ubuntu-latest
     needs: [validate]
     if: ${{ github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
-    environment: pub.dev
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      environment: pub.dev
+      working-directory: purchasely
+
+  wait-after-purchasely:
+    name: Wait for pub.dev indexing
+    runs-on: ubuntu-latest
+    needs: [publish-purchasely]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: "3.24.x"
-          channel: "stable"
-          cache: true
-
-      - name: Install dependencies
-        working-directory: purchasely
-        run: flutter pub get
-
-      - name: Publish to pub.dev
-        working-directory: purchasely
-        run: flutter pub publish --force
+      - run: sleep 30
 
   publish-google:
     name: Publish purchasely_google
-    runs-on: ubuntu-latest
-    needs: [publish-purchasely]
-    environment: pub.dev
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: "3.24.x"
-          channel: "stable"
-          cache: true
-
-      - name: Wait for pub.dev indexing
-        run: sleep 30
-
-      - name: Install dependencies
-        working-directory: purchasely_google
-        run: flutter pub get
-
-      - name: Publish to pub.dev
-        working-directory: purchasely_google
-        run: flutter pub publish --force
+    needs: [wait-after-purchasely]
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      environment: pub.dev
+      working-directory: purchasely_google
 
   publish-player:
     name: Publish purchasely_android_player
-    runs-on: ubuntu-latest
-    needs: [publish-purchasely]
-    environment: pub.dev
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: "3.24.x"
-          channel: "stable"
-          cache: true
-
-      - name: Wait for pub.dev indexing
-        run: sleep 30
-
-      - name: Install dependencies
-        working-directory: purchasely_android_player
-        run: flutter pub get
-
-      - name: Publish to pub.dev
-        working-directory: purchasely_android_player
-        run: flutter pub publish --force
+    needs: [wait-after-purchasely]
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      environment: pub.dev
+      working-directory: purchasely_android_player
 
   # ============================================
   # Summary


### PR DESCRIPTION
## Summary
The previous `flutter pub publish --force` job hung on interactive OAuth (localhost callback) because it never performed the OIDC token exchange with pub.dev.

Switch the 3 publish jobs to call the official reusable workflow [`dart-lang/setup-dart/.github/workflows/publish.yml@v1`](https://dart.dev/tools/pub/automated-publishing#triggering-publication-on-tag-push), which:
- sets up dart,
- exchanges the GitHub OIDC token for pub.dev credentials,
- runs `dart pub publish --force`.

The `validate` job (with `flutter pub publish --dry-run`) is unchanged.

A small `wait-after-purchasely` job preserves the 30s sleep before publishing `purchasely_google` and `purchasely_android_player`, since they depend on `purchasely_flutter` and need pub.dev to have indexed it.

## Prerequisite
Automated publishing has been configured on pub.dev for the 3 packages with:
- Repository: `Purchasely/Purchasely-Flutter`
- Tag pattern: `v{{version}}`
- Required GitHub Actions environment: `pub.dev`

## Test plan
- [ ] CI green
- [ ] After merge, retag `v5.7.3` to retrigger publish.yml — expect successful publish to pub.dev for the 3 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)