### PR TITLE
fix: v6 Go/No-Go audit findings (M1-M3, m1-m10)

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -31,7 +31,9 @@ sed -i '' "s/^.*version:.*$/version: ${VERSION}/" purchasely_android_player/pubs
 sed -i '' "s/^.*Purchasely.sdkBridgeVersion.*$/\t  Purchasely.sdkBridgeVersion = \"${VERSION}\"/" purchasely/android/src/main/kotlin/io/purchasely/purchasely_flutter/PurchaselyFlutterPlugin.kt
 
 # Replace version number in ios plugin
-sed -i '' "s/^.*Purchasely.setSdkBridgeVersion.*$/\t\tPurchasely.setSdkBridgeVersion(\"${VERSION}\")/" purchasely/ios/purchasely_flutter/Classes/SwiftPurchaselyFlutterPlugin.swift
+# v6 sets the bridge version via the builder chain `.sdkBridgeVersion("…")`
+# (12-space indentation inside the Purchasely.apiKey(...) chain).
+sed -i '' "s/^.*\.sdkBridgeVersion(.*$/            .sdkBridgeVersion(\"${VERSION}\")/" purchasely/ios/purchasely_flutter/Classes/SwiftPurchaselyFlutterPlugin.swift
 
 # Update all CHANGELOG.md files
 update_changelog "purchasely/CHANGELOG.md"

--- a/purchasely/android/src/main/kotlin/io/purchasely/purchasely_flutter/NativeView.kt
+++ b/purchasely/android/src/main/kotlin/io/purchasely/purchasely_flutter/NativeView.kt
@@ -36,8 +36,11 @@ internal class NativeView(
                 // sink and envelope shape as the full-screen path, keyed by the
                 // request's `requestId`, so the Dart `onDismissed` callback (and the
                 // pending `display()` future) fire for the inline path too.
+                // Only the loaded handle and display callback are dropped: the
+                // prepared request stays registered so a re-display of the same
+                // Dart handle keeps its original source (same policy as the
+                // full-screen path).
                 PurchaselyFlutterPlugin.loadedPresentations.remove(requestId)
-                PurchaselyFlutterPlugin.preparedRequests.remove(requestId)
                 PurchaselyFlutterPlugin.displayCallbacks.remove(requestId)
                 PurchaselyFlutterPlugin.emitPresentationEvent(
                     PurchaselyFlutterPlugin.eventEnvelope("onDismissed", requestId).apply {
@@ -47,6 +50,16 @@ internal class NativeView(
             }
             Log.d("Purchasely", "Presentation built successfully.")
             layout.addView(presentationView)
+
+            // The native SDK fires no `onPresented` for an embedded view —
+            // synthesise it once the view is mounted so the Dart-side
+            // request/presentation `onPresented` callback fires for the inline
+            // path too (parity with the full-screen path).
+            PurchaselyFlutterPlugin.emitPresentationEvent(
+                PurchaselyFlutterPlugin.eventEnvelope("onPresented", requestId).apply {
+                    put("presentation", PurchaselyFlutterPlugin.presentationToMap(presentation))
+                }
+            )
         } else {
             Log.e("Purchasely", "Loaded Presentation not found for requestId=$requestId; nothing to display inline.")
         }

--- a/purchasely/android/src/main/kotlin/io/purchasely/purchasely_flutter/PurchaselyFlutterPlugin.kt
+++ b/purchasely/android/src/main/kotlin/io/purchasely/purchasely_flutter/PurchaselyFlutterPlugin.kt
@@ -36,6 +36,9 @@ import io.purchasely.models.PLYPresentationPlan
 import io.purchasely.models.PLYProduct
 import kotlinx.coroutines.*
 import io.purchasely.ext.Purchasely
+// `Colors` is the (public) type of the public `PLYTransition.backgroundColors`
+// field; it lives under `internal.` by package convention only.
+import io.purchasely.internal.presentation.models.Colors
 import io.purchasely.models.PLYError
 import io.purchasely.views.presentation.PLYThemeMode
 import io.purchasely.views.presentation.models.PLYDimensionType
@@ -509,6 +512,7 @@ class PurchaselyFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, 
         val allowDeeplink = a["allowDeeplink"] as? Boolean
         val allowCampaigns = a["allowCampaigns"] as? Boolean ?: true
         val deeplink = (a["deeplink"] as? String)?.takeIf { it.isNotBlank() }
+        val automaticDeeplinkHandling = a["automaticDeeplinkHandling"] as? Boolean
 
         Purchasely.Builder(context)
             .apiKey(apiKey)
@@ -522,6 +526,9 @@ class PurchaselyFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, 
                 // Cold-start deeplink: replayed automatically once started, so
                 // the host does not need a separate handleDeeplink() call.
                 deeplink?.let { this.handleDeeplink(Uri.parse(it)) }
+                // v6 auto-intercepts Purchasely deeplinks by default; hosts that
+                // route intents themselves can opt out from the Dart builder.
+                automaticDeeplinkHandling?.let { this.automaticDeeplinkHandling(it) }
             }
             .build()
 
@@ -900,10 +907,18 @@ class PurchaselyFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, 
         // is deprecated and intentionally not set.
         val width = parseDimension(map["width"])
         val height = parseDimension(map["height"])
+        // drawer/popin background override (`{ light, dark }` hex strings).
+        val backgroundColors = (map["backgroundColors"] as? Map<*, *>)?.let { colors ->
+            Colors(
+                light = colors["light"] as? String,
+                dark = colors["dark"] as? String,
+            )
+        }
         return PLYTransition(
             type = type,
             width = width,
             height = height,
+            backgroundColors = backgroundColors,
             dismissible = dismissible,
         )
     }
@@ -1013,7 +1028,15 @@ class PurchaselyFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, 
         Purchasely.synchronize(
             onSuccess = { result.safeSuccess(true) },
             onError = { error ->
-                result.safeError("-1", error?.message ?: "Synchronization failed", error)
+                if (error == null) {
+                    // A null PLYError means the receipt is still PENDING (deferred
+                    // purchase awaiting backend validation) — a normal state, not
+                    // a failure. Resolve `false` ("not completed yet") instead of
+                    // throwing a PlatformException at the Dart caller.
+                    result.safeSuccess(false)
+                } else {
+                    result.safeError("-1", error.message ?: "Synchronization failed", error)
+                }
             }
         )
     }
@@ -1472,7 +1495,7 @@ class PurchaselyFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, 
             )
         }
 
-        private fun presentationToMap(p: PLYPresentationBase.Loaded): Map<String, Any?> {
+        internal fun presentationToMap(p: PLYPresentationBase.Loaded): Map<String, Any?> {
             return mapOf(
                 "screenId" to p.screenId,
                 "placementId" to p.placementId,

--- a/purchasely/android/src/main/kotlin/io/purchasely/purchasely_flutter/PurchaselyFlutterPlugin.kt
+++ b/purchasely/android/src/main/kotlin/io/purchasely/purchasely_flutter/PurchaselyFlutterPlugin.kt
@@ -908,11 +908,14 @@ class PurchaselyFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, 
         val width = parseDimension(map["width"])
         val height = parseDimension(map["height"])
         // drawer/popin background override (`{ light, dark }` hex strings).
+        // Only materialize Colors when at least one value is present — an
+        // empty map must not override native defaults (mirrors iOS, whose
+        // parseColors returns nil when both are absent).
         val backgroundColors = (map["backgroundColors"] as? Map<*, *>)?.let { colors ->
-            Colors(
-                light = colors["light"] as? String,
-                dark = colors["dark"] as? String,
-            )
+            val light = (colors["light"] as? String)?.takeIf { it.isNotBlank() }
+            val dark = (colors["dark"] as? String)?.takeIf { it.isNotBlank() }
+            if (light == null && dark == null) null
+            else Colors(light = light, dark = dark)
         }
         return PLYTransition(
             type = type,
@@ -1454,8 +1457,19 @@ class PurchaselyFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, 
 
         // Prepared/loaded presentations keyed by Dart requestId. They are retained after
         // dismissal so a Dart Presentation handle can be displayed again and so the inline
-        // platform view can resolve a preloaded requestId. There is no native dispose API yet.
-        val preparedRequests = ConcurrentHashMap<String, PLYPresentationBase.Prepared>()
+        // platform view can resolve a preloaded requestId. There is no native dispose API,
+        // so the prepared registry is FIFO-capped (mirrors iOS): evicting the eldest is
+        // safe because a Dart re-display resends the full original source — an evicted
+        // request is rebuilt identically from the display args.
+        private const val REQUEST_RETENTION_CAP = 64
+        val preparedRequests: MutableMap<String, PLYPresentationBase.Prepared> =
+            Collections.synchronizedMap(
+                object : LinkedHashMap<String, PLYPresentationBase.Prepared>() {
+                    override fun removeEldestEntry(
+                        eldest: MutableMap.MutableEntry<String, PLYPresentationBase.Prepared>?
+                    ) = size > REQUEST_RETENTION_CAP
+                }
+            )
         val loadedPresentations = ConcurrentHashMap<String, PLYPresentationBase.Loaded>()
         val displayCallbacks = ConcurrentHashMap<String, (PLYPresentationOutcome) -> Unit>()
 

--- a/purchasely/example/ios/Podfile.lock
+++ b/purchasely/example/ios/Podfile.lock
@@ -28,7 +28,7 @@ SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   Purchasely: ffb024d48dbb2f381cef14c9e3051d1026b7fbce
-  purchasely_flutter: fa005223aff64c54c1323366e41fa14dddf18fb0
+  purchasely_flutter: 3c2dfce6f4b55f4df9c709932b3169805bf75a33
 
 PODFILE CHECKSUM: 90bf4859e53005cca57842574aa3859124fcaa16
 

--- a/purchasely/ios/purchasely_flutter/Classes/NativeView.swift
+++ b/purchasely/ios/purchasely_flutter/Classes/NativeView.swift
@@ -60,6 +60,20 @@ class NativeView: NSObject, FlutterPlatformView {
                 rootVC.addChild(controller)
                 controller.didMove(toParent: rootVC)
             }
+
+            // The native SDK fires no `onPresented` for an embedded controller —
+            // synthesise it once the view is mounted so the Dart-side
+            // request/presentation `onPresented` callback fires for the inline
+            // path too (parity with the full-screen path).
+            if let requestId = _requestId,
+               let presentation = SwiftPurchaselyFlutterPlugin.loadedPresentations[requestId] {
+                SwiftPurchaselyFlutterPlugin.emitPresentationEvent([
+                    "event": "onPresented",
+                    "requestId": requestId,
+                    "presentation": SwiftPurchaselyFlutterPlugin.presentationMap(
+                        presentation, requestId: requestId),
+                ])
+            }
         }
 
         UIDevice.current.beginGeneratingDeviceOrientationNotifications()
@@ -109,8 +123,10 @@ class NativeView: NSObject, FlutterPlatformView {
         return UIApplication.shared.delegate?.window??.rootViewController
     }
 
-    /// Emits the `onDismissed` envelope once, mirroring the full-screen path,
-    /// and clears the request's static state so a re-display re-registers.
+    /// Emits the `onDismissed` envelope once, mirroring the full-screen path.
+    /// Only the loaded handle is dropped: the request and its contentId stay
+    /// registered so a Dart-side re-display() of the same handle keeps its
+    /// original source (placement/screen) — same policy as the full-screen path.
     private func emitDismissed(requestId: String, outcome: PLYPresentationOutcome) {
         guard !_didEmitDismissed else { return }
         _didEmitDismissed = true
@@ -123,8 +139,6 @@ class NativeView: NSObject, FlutterPlatformView {
             ) as Any?,
         ])
         SwiftPurchaselyFlutterPlugin.loadedPresentations.removeValue(forKey: requestId)
-        SwiftPurchaselyFlutterPlugin.requests.removeValue(forKey: requestId)
-        SwiftPurchaselyFlutterPlugin.requestContentIds.removeValue(forKey: requestId)
     }
 
     private func cleanupController() {

--- a/purchasely/ios/purchasely_flutter/Classes/SwiftPurchaselyFlutterPlugin.swift
+++ b/purchasely/ios/purchasely_flutter/Classes/SwiftPurchaselyFlutterPlugin.swift
@@ -18,6 +18,23 @@ public class SwiftPurchaselyFlutterPlugin: NSObject, FlutterPlugin {
     // our own registry of what was passed in so `presentationToMap` can echo
     // it back instead of hardcoding null (FLT-W-06 / REC-09).
     static var requestContentIds: [String: String] = [:]
+    // FIFO cap on the retained registries: requestIds are random per Dart
+    // build(), so without a bound they'd grow for the app's lifetime. Evicting
+    // the oldest is safe because a Dart re-display resends the full original
+    // source — an evicted request is rebuilt identically from the display args.
+    static let requestRetentionCap = 64
+    private static var requestOrder: [String] = []
+
+    static func retainRequest(_ requestId: String) {
+        requestOrder.removeAll { $0 == requestId }
+        requestOrder.append(requestId)
+        while requestOrder.count > requestRetentionCap {
+            let evicted = requestOrder.removeFirst()
+            requests.removeValue(forKey: evicted)
+            requestContentIds.removeValue(forKey: evicted)
+            loadedPresentations.removeValue(forKey: evicted)
+        }
+    }
     // invocationId -> SDK interceptor completion. Single-shot, removed on resolve.
     private static var pendingInterceptors: [String: (PLYInterceptResult) -> Void] = [:]
 
@@ -395,6 +412,7 @@ public class SwiftPurchaselyFlutterPlugin: NSObject, FlutterPlugin {
 
         let request = builder.build()
         SwiftPurchaselyFlutterPlugin.requests[requestId] = request
+        SwiftPurchaselyFlutterPlugin.retainRequest(requestId)
         return request
     }
 

--- a/purchasely/ios/purchasely_flutter/Classes/SwiftPurchaselyFlutterPlugin.swift
+++ b/purchasely/ios/purchasely_flutter/Classes/SwiftPurchaselyFlutterPlugin.swift
@@ -88,6 +88,13 @@ public class SwiftPurchaselyFlutterPlugin: NSObject, FlutterPlugin {
                                     requestId: requestId) ?? [:]
     }
 
+    /// Static accessor to the presentation serializer so the inline NativeView
+    /// emits the exact same `presentation` shape as the full-screen path.
+    static func presentationMap(_ presentation: PLYPresentation,
+                                requestId: String) -> [String: Any] {
+        return shared?.presentationToMap(presentation, requestId: requestId) ?? [:]
+    }
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "purchasely",
                                            binaryMessenger: registrar.messenger())
@@ -341,6 +348,12 @@ public class SwiftPurchaselyFlutterPlugin: NSObject, FlutterPlugin {
         if let hex = args["progressColor"] as? String, let color = UIColor.ply_from(hex: hex) {
             _ = builder.progressColor(color)
         }
+        if let displayCloseButton = args["displayCloseButton"] as? Bool {
+            _ = builder.displayCloseButton(displayCloseButton)
+        }
+        if let displayBackButton = args["displayBackButton"] as? Bool {
+            _ = builder.displayBackButton(displayBackButton)
+        }
 
         // Builder-seeded callbacks are transferred onto the loaded presentation
         // automatically by the SDK. They run on the main actor; we emit on the
@@ -371,12 +384,13 @@ public class SwiftPurchaselyFlutterPlugin: NSObject, FlutterPlugin {
                 "requestId": requestId,
                 "outcome": self?.outcomeToMap(outcome, presentation: presentation, error: nil, requestId: requestId) as Any?,
             ])
-            // Full-screen dismiss: clear all per-request state so the
-            // registries don't grow unbounded and stale handles aren't
-            // addressable via close/back. Mirrors the inline NativeView cleanup.
+            // Full-screen dismiss: drop only the loaded handle (stale once
+            // dismissed). The request and its contentId stay registered so a
+            // Dart-side re-display() of the same handle reuses the original
+            // native request — and thus its source (placement/screen) — instead
+            // of being rebuilt against the default source. Mirrors Android,
+            // which keeps preparedRequests across dismissals.
             SwiftPurchaselyFlutterPlugin.loadedPresentations.removeValue(forKey: requestId)
-            SwiftPurchaselyFlutterPlugin.requests.removeValue(forKey: requestId)
-            SwiftPurchaselyFlutterPlugin.requestContentIds.removeValue(forKey: requestId)
         }
 
         let request = builder.build()
@@ -687,13 +701,22 @@ public class SwiftPurchaselyFlutterPlugin: NSObject, FlutterPlugin {
     }
 
     private static func interceptorInfoToMap(_ info: PLYInterceptorInfo) -> [String: Any?] {
-        // Mirror Android's shape — only the keys consumed by the Dart façade.
+        // Mirror Android's shape, which serializes the full presentation map —
+        // the Dart façade parses it with the tolerant PLYPresentation.fromMap,
+        // so attribution fields (audience/AB test/campaign) survive the bridge.
         return [
             "contentId": info.contentId,
             "presentation": info.presentation.map { p in
                 [
                     "screenId": p.screenId,
                     "placementId": p.placementId as Any,
+                    "audienceId": p.audienceId as Any,
+                    "abTestId": p.abTestId as Any,
+                    "abTestVariantId": p.abTestVariantId as Any,
+                    "campaignId": p.campaignId as Any,
+                    "flowId": p.flowId as Any,
+                    "language": p.language,
+                    "type": p.type.rawValue,
                 ]
             } as Any?,
         ]
@@ -708,6 +731,17 @@ public class SwiftPurchaselyFlutterPlugin: NSObject, FlutterPlugin {
             map["plan"] = [
                 "vendorId": plan.vendorId as Any,
                 "productId": plan.appleProductId as Any?,
+            ]
+        }
+        // Promotional offer attached to the tapped plan (`offer` on the wire,
+        // matching Android's shape). iOS has no `subscriptionOffer` equivalent —
+        // that payload field stays Android-only (Google Play base-plan /
+        // offer-token concepts). PLYPromoOffer.publicId is internal on iOS and
+        // intentionally omitted.
+        if let offer = params.promoOffer {
+            map["offer"] = [
+                "vendorId": offer.vendorId,
+                "storeOfferId": offer.storeOfferId,
             ]
         }
         if let presentationId = params.presentation { map["presentationId"] = presentationId }
@@ -768,6 +802,16 @@ public class SwiftPurchaselyFlutterPlugin: NSObject, FlutterPlugin {
         }
     }
 
+    /// Parses the Dart `{ "light": "#RRGGBB", "dark": "#RRGGBB" }` map into a
+    /// native `PLYColors`. Returns `nil` when absent so the SDK default applies.
+    private static func parseColors(_ raw: Any?) -> PLYColors? {
+        guard let map = raw as? [String: Any] else { return nil }
+        let light = (map["light"] as? String).flatMap { UIColor.ply_from(hex: $0) }
+        let dark = (map["dark"] as? String).flatMap { UIColor.ply_from(hex: $0) }
+        if light == nil && dark == nil { return nil }
+        return PLYColors(lightColor: light, darkColor: dark)
+    }
+
     private static func parseTransition(_ map: [String: Any]?) -> PLYTransition? {
         guard let map = map, let type = map["type"] as? String else { return nil }
         let dismissible = map["dismissible"] as? Bool ?? true
@@ -775,12 +819,24 @@ public class SwiftPurchaselyFlutterPlugin: NSObject, FlutterPlugin {
         // drives drawer + popin). `nil` means "hug" — size to content.
         let width = parseDimension(map["width"])
         let height = parseDimension(map["height"])
+        // drawer/popin background override; built via the designated initializer
+        // because the `.drawer`/`.popin` factories don't take colors.
+        let colors = parseColors(map["backgroundColors"])
         switch type {
         case "fullScreen":    return .fullScreen
         case "push":          return .push
-        case "modal":         return .modal
-        case "drawer":        return .drawer(height: height, dismissible: dismissible)
-        case "popin":         return .popin(width: width, height: height, dismissible: dismissible)
+        case "modal":         return .modal(dismissible: dismissible)
+        case "drawer":
+            return PLYTransition(type: .drawer,
+                                 height: height,
+                                 backgroundColors: colors,
+                                 dismissible: dismissible)
+        case "popin":
+            return PLYTransition(type: .popin,
+                                 height: height,
+                                 width: width,
+                                 backgroundColors: colors,
+                                 dismissible: dismissible)
         case "inlinePaywall": return .inlinePaywall
         default: return nil
         }

--- a/purchasely/lib/native_view_widget.dart
+++ b/purchasely/lib/native_view_widget.dart
@@ -16,12 +16,14 @@ import 'src/presentation_request.dart';
 /// `{ "requestId": <id> }` creation params. The native side resolves the
 /// preloaded presentation from that id and renders it inline.
 ///
-/// Lifecycle: the embedded (inline) path surfaces its dismissal/outcome through
-/// the same `purchasely-presentation-events` channel as a full-screen
-/// presentation, keyed by `requestId`. When the inline presentation is
-/// dismissed, the native view emits the same `onDismissed` envelope (with the
-/// `display()`-style [PLYPresentationOutcome]) as the modal path, so the request's
-/// [PLYPresentationRequest.onDismissed] callback fires for the inline view too.
+/// Lifecycle: the embedded (inline) path surfaces its events through the same
+/// `purchasely-presentation-events` channel as a full-screen presentation,
+/// keyed by `requestId`. Once the native view is mounted it emits the same
+/// `onPresented` envelope as the modal path, and when the inline presentation
+/// is dismissed it emits the same `onDismissed` envelope (with the
+/// `display()`-style [PLYPresentationOutcome]) — so the request's
+/// [PLYPresentationRequest.onPresented] and
+/// [PLYPresentationRequest.onDismissed] callbacks fire for the inline view too.
 class PLYPresentationView extends StatefulWidget {
   /// The presentation request to render inline. Build it with
   /// `PLYPresentationBuilder.placement(...)...build()`.

--- a/purchasely/lib/purchasely_flutter.dart
+++ b/purchasely/lib/purchasely_flutter.dart
@@ -197,15 +197,26 @@ class Purchasely {
     }
   }
 
-  static Future<bool> restoreAllProducts() async {
-    final bool restored = await _channel.invokeMethod('restoreAllProducts');
-    return restored;
+  /// Restores every purchase previously made by the user (App Store /
+  /// Google Play restore flow).
+  ///
+  /// On a device without a working store (e.g. an emulator without Google
+  /// Play), the native call may never resolve — pass [timeout] to fail with a
+  /// [TimeoutException] instead of awaiting forever.
+  static Future<bool> restoreAllProducts({Duration? timeout}) async {
+    final call = _channel.invokeMethod('restoreAllProducts');
+    final dynamic restored =
+        await (timeout == null ? call : call.timeout(timeout));
+    return restored == true;
   }
 
-  static Future<bool> silentRestoreAllProducts() async {
-    final bool restored =
-        await _channel.invokeMethod('silentRestoreAllProducts');
-    return restored;
+  /// Silent variant of [restoreAllProducts] (no store sign-in prompt on iOS).
+  /// Same [timeout] semantics.
+  static Future<bool> silentRestoreAllProducts({Duration? timeout}) async {
+    final call = _channel.invokeMethod('silentRestoreAllProducts');
+    final dynamic restored =
+        await (timeout == null ? call : call.timeout(timeout));
+    return restored == true;
   }
 
   /// Forces a synchronization of the user's purchases with the Purchasely
@@ -216,6 +227,10 @@ class Purchasely {
   /// synchronization actually completes and throws a [PlatformException] if it
   /// failed — instead of the previous fire-and-forget behaviour. `await` it
   /// before chaining a follow-up presentation that targets subscribers.
+  ///
+  /// Resolves `false` when the receipt is still pending store/backend
+  /// validation (deferred purchase, Android) — a normal transient state, not
+  /// a failure.
   static Future<bool> synchronize() async {
     final result = await _channel.invokeMethod('synchronize');
     return result == true;
@@ -414,6 +429,14 @@ class Purchasely {
     return PLYSubscriptionSource.none;
   }
 
+  /// Hands a deeplink to the SDK; returns `true` when the SDK handled it
+  /// (e.g. by opening the targeted placement/presentation).
+  ///
+  /// A handled deeplink fires `DEEPLINK_OPENED` and `PRESENTATION_LOADED` /
+  /// `PRESENTATION_VIEWED` (never `PRESENTATION_OPENED`), but the relative
+  /// order of `DEEPLINK_OPENED` and `PRESENTATION_LOADED` differs between the
+  /// native SDKs (iOS emits `DEEPLINK_OPENED` first, Android may emit
+  /// `PRESENTATION_LOADED` first) — don't rely on their ordering.
   static Future<bool> handleDeeplink(String deepLink) async {
     return await _channel.invokeMethod(
         'handleDeeplink', <String, dynamic>{'deeplink': deepLink});

--- a/purchasely/lib/src/bridge.dart
+++ b/purchasely/lib/src/bridge.dart
@@ -99,6 +99,14 @@ class PurchaselyBridge {
   final Map<String, PLYActionInterceptorHandler> _interceptors =
       <String, PLYActionInterceptorHandler>{};
 
+  /// Originating request `source` maps keyed by requestId, retained across
+  /// dismissals so a handle-based re-display resends the ORIGINAL source.
+  /// Inferring the source from the loaded presentation would narrow a dynamic
+  /// default source to whatever screen/placement it happened to resolve to,
+  /// bypassing updated targeting on the rebuild path.
+  final Map<String, Map<String, Object?>> _originSources =
+      <String, Map<String, Object?>>{};
+
   /// Global dismiss handler for SDK-owned presentations (campaigns,
   /// deeplinks, promoted in-app purchases).
   void Function(PLYPresentationOutcome outcome)?
@@ -122,6 +130,7 @@ class PurchaselyBridge {
     _eventSub = null;
     _entries.clear();
     _interceptors.clear();
+    _originSources.clear();
     _defaultPresentationDismissHandler = null;
   }
 
@@ -204,9 +213,10 @@ class PurchaselyBridge {
           'requestId': presentation.requestId,
           // The native side may have to rebuild the request from these args
           // (e.g. a retry after a failed display dropped the native request):
-          // resend the source so a rebuild targets the original
-          // placement/screen instead of the default source.
-          'source': _sourceMapForPresentation(presentation),
+          // resend the ORIGINAL source — falling back to inference from the
+          // handle only when the bridge was re-created (e.g. hot restart).
+          'source': _originSources[presentation.requestId] ??
+              _sourceMapForPresentation(presentation),
           if (presentation.contentId != null)
             'contentId': presentation.contentId,
           if (transition != null) 'transition': transition.toMap(),
@@ -443,9 +453,12 @@ class PurchaselyBridge {
     return Map<String, Object?>.from(request.toMap());
   }
 
-  /// Reconstructs the request `source` map from a loaded presentation handle:
-  /// a placement-sourced presentation carries its placementId; a screen-sourced
-  /// one only its screenId.
+  /// Degraded fallback when the originating source is unknown (bridge
+  /// re-created, e.g. hot restart): infers a source from the loaded
+  /// presentation handle. A placement-sourced presentation carries its
+  /// placementId; a screen-sourced one only its screenId. Note this can pin a
+  /// default-sourced presentation to its resolved screen — the retained
+  /// [_originSources] entry is always preferred.
   Map<String, Object?> _sourceMapForPresentation(PLYPresentation p) {
     final placementId = p.placementId;
     if (placementId != null && placementId.isNotEmpty) {
@@ -459,6 +472,7 @@ class PurchaselyBridge {
   }
 
   void _registerRequest(PLYPresentationRequest request) {
+    _originSources[request.requestId] = request.source.toMap();
     _entries.putIfAbsent(
       request.requestId,
       () => _RequestEntry(request),

--- a/purchasely/lib/src/bridge.dart
+++ b/purchasely/lib/src/bridge.dart
@@ -202,6 +202,13 @@ class PurchaselyBridge {
         'display',
         <String, Object?>{
           'requestId': presentation.requestId,
+          // The native side may have to rebuild the request from these args
+          // (e.g. a retry after a failed display dropped the native request):
+          // resend the source so a rebuild targets the original
+          // placement/screen instead of the default source.
+          'source': _sourceMapForPresentation(presentation),
+          if (presentation.contentId != null)
+            'contentId': presentation.contentId,
           if (transition != null) 'transition': transition.toMap(),
         },
       );
@@ -434,6 +441,21 @@ class PurchaselyBridge {
 
   Map<String, Object?> _argsForRequest(PLYPresentationRequest request) {
     return Map<String, Object?>.from(request.toMap());
+  }
+
+  /// Reconstructs the request `source` map from a loaded presentation handle:
+  /// a placement-sourced presentation carries its placementId; a screen-sourced
+  /// one only its screenId.
+  Map<String, Object?> _sourceMapForPresentation(PLYPresentation p) {
+    final placementId = p.placementId;
+    if (placementId != null && placementId.isNotEmpty) {
+      return {'kind': 'placementId', 'id': placementId};
+    }
+    final screenId = p.screenId;
+    if (screenId != null && screenId.isNotEmpty) {
+      return {'kind': 'screenId', 'id': screenId};
+    }
+    return {'kind': 'defaultSource'};
   }
 
   void _registerRequest(PLYPresentationRequest request) {

--- a/purchasely/lib/src/presentation_builder.dart
+++ b/purchasely/lib/src/presentation_builder.dart
@@ -84,15 +84,15 @@ class PLYPresentationBuilder {
     return this;
   }
 
-  /// Whether the SDK should render its close button.
-  /// Android only at the moment — no-op on iOS.
+  /// Whether the SDK should render its close button. Supported on both
+  /// platforms; `false` suppresses a backend-configured close button.
   PLYPresentationBuilder displayCloseButton(bool show) {
     _displayCloseButton = show;
     return this;
   }
 
-  /// Whether the SDK should render its back button.
-  /// Android only at the moment — no-op on iOS.
+  /// Whether the SDK should render its back button. Supported on both
+  /// platforms; `false` suppresses a backend-configured back button.
   PLYPresentationBuilder displayBackButton(bool show) {
     _displayBackButton = show;
     return this;

--- a/purchasely/lib/src/purchasely_builder.dart
+++ b/purchasely/lib/src/purchasely_builder.dart
@@ -31,6 +31,7 @@ class PurchaselyBuilder {
   bool? _allowDeeplink;
   bool _allowCampaigns;
   String? _deeplink;
+  bool? _automaticDeeplinkHandling;
   // Android only
   List<PLYStore> _stores;
   // iOS only
@@ -96,6 +97,16 @@ class PurchaselyBuilder {
     return this;
   }
 
+  /// Android-only: whether the SDK automatically intercepts Purchasely
+  /// deeplinks (`true` by default in v6). Disable it to fully control routing
+  /// yourself (e.g. `singleTask` activities that re-dispatch intents manually)
+  /// and call [Purchasely.handleDeeplink] where appropriate. iOS never
+  /// auto-intercepts, so this modifier is a no-op there.
+  PurchaselyBuilder automaticDeeplinkHandling(bool enabled) {
+    _automaticDeeplinkHandling = enabled;
+    return this;
+  }
+
   /// Android-only: stores the SDK is allowed to use (priority order). On iOS
   /// this modifier is a no-op.
   PurchaselyBuilder stores(List<PLYStore> stores) {
@@ -126,6 +137,8 @@ class PurchaselyBuilder {
         'allowDeeplink': _allowDeeplink,
         'allowCampaigns': _allowCampaigns,
         if (_deeplink != null) 'deeplink': _deeplink,
+        if (_automaticDeeplinkHandling != null)
+          'automaticDeeplinkHandling': _automaticDeeplinkHandling,
         'stores': _stores.map((s) => s.name).toList(),
         'storekitVersion': _storekitVersion.name,
       },

--- a/purchasely/test/bridge_test.dart
+++ b/purchasely/test/bridge_test.dart
@@ -509,6 +509,37 @@ void main() {
       await outcome;
     });
 
+    test(
+        're-display() preserves a dynamic default source (not the resolved '
+        'screen)', () async {
+      // Regression (PR #136 review, P2): a presentation built from
+      // defaultSource() resolves to a concrete screen/placement, but a
+      // re-display must resend the ORIGINAL default source — pinning the
+      // resolved screen would bypass updated targeting on a native rebuild.
+      final request = PLYPresentationBuilder.defaultSource().build();
+      final presentation = await request.preload();
+      // The mocked preload response carries a resolved screenId, which the
+      // fallback inference would otherwise pick up.
+      expect(presentation.screenId, isNotNull);
+      calls.clear();
+
+      // ignore: unawaited_futures
+      final outcome = presentation.display(const PLYTransition.modal());
+      await Future<void>.delayed(Duration.zero);
+
+      final displayCall = calls.firstWhere((c) => c.method == 'display');
+      final args = displayCall.arguments as Map;
+      expect((args['source'] as Map)['kind'], 'defaultSource');
+      expect((args['source'] as Map).containsKey('id'), false);
+
+      await emitEvent(<String, Object?>{
+        'event': 'onDismissed',
+        'requestId': presentation.requestId,
+        'outcome': <String, Object?>{'purchaseResult': 'cancelled'},
+      });
+      await outcome;
+    });
+
     test('onCloseRequested fires the builder callback', () async {
       var fired = false;
       final request =

--- a/purchasely/test/bridge_test.dart
+++ b/purchasely/test/bridge_test.dart
@@ -481,6 +481,34 @@ void main() {
       expect((await secondOutcome).purchaseResult, PLYPurchaseResult.purchased);
     });
 
+    test('re-display() resends the source so a native rebuild keeps it',
+        () async {
+      // Regression (v6 audit M2): after a dismiss the native side may have to
+      // rebuild the request from the display args. A handle-based display()
+      // must therefore carry the original source, not just the requestId —
+      // otherwise the rebuild falls back to the default source.
+      final request = PLYPresentationBuilder.placement('home').build();
+      final presentation = await request.preload();
+      calls.clear();
+
+      // ignore: unawaited_futures
+      final outcome = presentation.display(const PLYTransition.modal());
+      await Future<void>.delayed(Duration.zero);
+
+      final displayCall = calls.firstWhere((c) => c.method == 'display');
+      final args = displayCall.arguments as Map;
+      expect(args['requestId'], presentation.requestId);
+      expect((args['source'] as Map)['kind'], 'placementId');
+      expect((args['source'] as Map)['id'], 'home');
+
+      await emitEvent(<String, Object?>{
+        'event': 'onDismissed',
+        'requestId': presentation.requestId,
+        'outcome': <String, Object?>{'purchaseResult': 'cancelled'},
+      });
+      await outcome;
+    });
+
     test('onCloseRequested fires the builder callback', () async {
       var fired = false;
       final request =

--- a/purchasely/test/platform_channel_test.dart
+++ b/purchasely/test/platform_channel_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:purchasely_flutter/purchasely_flutter.dart';
@@ -155,6 +157,23 @@ void main() {
         await Purchasely.silentRestoreAllProducts();
 
         expect(methodCalls.first.method, 'silentRestoreAllProducts');
+      });
+
+      test('restoreAllProducts times out when native never resolves',
+          () async {
+        // Regression (v6 audit m7): without a Play Store the native restore
+        // can hang forever — the optional timeout must surface it.
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) {
+          // Never resolve.
+          return Completer<Object?>().future;
+        });
+
+        await expectLater(
+          Purchasely.restoreAllProducts(
+              timeout: const Duration(milliseconds: 50)),
+          throwsA(isA<TimeoutException>()),
+        );
       });
     });
 

--- a/purchasely/test/platform_channel_test.dart
+++ b/purchasely/test/platform_channel_test.dart
@@ -159,8 +159,7 @@ void main() {
         expect(methodCalls.first.method, 'silentRestoreAllProducts');
       });
 
-      test('restoreAllProducts times out when native never resolves',
-          () async {
+      test('restoreAllProducts times out when native never resolves', () async {
         // Regression (v6 audit m7): without a Play Store the native restore
         // can hang forever — the optional timeout must surface it.
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger

--- a/purchasely/test/purchasely_flutter_test.dart
+++ b/purchasely/test/purchasely_flutter_test.dart
@@ -2058,6 +2058,7 @@ void main() {
           .allowDeeplink(true)
           .allowCampaigns(false)
           .handleDeeplink('app://ply/presentations/onboarding')
+          .automaticDeeplinkHandling(false)
           .stores([PLYStore.google, PLYStore.huawei, PLYStore.amazon])
           .storekitVersion(PLYStorekitVersion.storeKit1)
           .start();
@@ -2070,8 +2071,17 @@ void main() {
       expect(startCall.arguments['allowCampaigns'], false);
       expect(startCall.arguments['deeplink'],
           'app://ply/presentations/onboarding');
+      expect(startCall.arguments['automaticDeeplinkHandling'], false);
       expect(startCall.arguments['stores'], ['google', 'huawei', 'amazon']);
       expect(startCall.arguments['storekitVersion'], 'storeKit1');
+    });
+
+    test('start omits automaticDeeplinkHandling unless set', () async {
+      await Purchasely.apiKey('test-key').start();
+
+      final startCall = methodCalls.firstWhere((c) => c.method == 'start');
+      expect(
+          startCall.arguments.containsKey('automaticDeeplinkHandling'), false);
     });
 
     test('handleDeeplink(null) does not forward a cold-start deeplink',


### PR DESCRIPTION
## Contexte

Correctifs issus de l'audit Go/No-Go du merge v6 (3 audits de parité cross-SDK contre le tag natif 6.0.0-rc.3 + contre-expertise adversariale + E2E iOS/Android). Chaque finding Blocker/Major a été confirmé par un vérificateur indépendant avant fix.

## Majors corrigés

| # | Fix | Fichier |
|---|-----|---------|
| M1 | `PLYTransition.modal(dismissible: false)` ignoré sur iOS — un paywall obligatoire restait swipe-to-dismiss | `SwiftPurchaselyFlutterPlugin.swift` (parseTransition) |
| M2 | Re-`display()` d'une presentation préchargée après dismiss perdait la source (registres purgés au dismiss côté iOS ; Dart n'envoyait que le requestId) | Swift (rétention des registres, parité Android) + `bridge.dart` (resend source/contentId) |
| M3 | `publish.sh:34` : le sed iOS ciblait le littéral v5 `Purchasely.setSdkBridgeVersion` → no-op silencieux, la release aurait publié une bridge version iOS périmée | `publish.sh` |

## Minors corrigés

- **m1** — payload interceptor `purchase` iOS : ajoute `offer` (`{vendorId, storeOfferId}`). `subscriptionOffer` reste Android-only (concepts Google Play) ; `publicId` est interne sur iOS.
- **m2** — `interceptorInfoToMap` iOS : presentation complète (audience/AB test/campaign/flow/language/type).
- **m3** — `displayCloseButton`/`displayBackButton` maintenant câblés sur iOS (docs Dart mises à jour).
- **m4** — `backgroundColors` des transitions drawer/popin câblé sur **les deux** plateformes (init désigné `PLYTransition` + `PLYColors` sur iOS ; type public `Colors` sur Android).
- **m5** — la vue inline émet `onPresented` au montage sur **les deux** plateformes (le natif n'en émet pas pour l'embedded) ; doc du widget mise à jour.
- **m6** — `synchronize` Android : `PLYError` null (reçu PENDING / achat différé) résout `false` au lieu de jeter une `PlatformException`.
- **m7** — `restoreAllProducts`/`silentRestoreAllProducts` : paramètre `timeout` optionnel (hang prouvé en E2E sur émulateur sans Play Store).
- **m8** — doc : divergence d'ordre des events deeplink entre iOS et Android (ne pas s'appuyer sur l'ordre).
- **m9** — `PurchaselyBuilder.automaticDeeplinkHandling(bool)` exposé (opt-out Android de l'auto-interception v6 ; no-op iOS).
- **m10** — drift rc.3→develop iOS (`oneSignalPlayerId`, 2 events supprimés) : aucun impact bridge, aucun changement requis.

## Limitations natives documentées (non corrigeables dans le bridge)

- `closeReason` absent du payload interceptor close/closeAll sur iOS (`PLYPresentationActionParameters` ne l'expose pas) — défaut Dart `programmatic`.
- `subscriptionOffer` absent sur iOS (concept Google Play).

## Vérifications

- `flutter analyze lib test` : 0 issue
- `flutter test` : **297/297** verts (3 nouveaux tests : source du re-display, wiring `automaticDeeplinkHandling`, timeout restore)
- `flutter build ios --simulator` (example) : ✓
- `flutter build apk --debug` (example) : ✓ (io.purchasely:core:6.0.0-rc.3)
- `./gradlew :purchasely_flutter:testDebugUnitTest` : 13/13, 0 échec

🤖 Generated with [Claude Code](https://claude.com/claude-code)