### PR TITLE
feat: exposer le commitment Apple (iOS 26.4+) dans le bridge Flutter

### DIFF
--- a/MIGRATION-v6.md
+++ b/MIGRATION-v6.md
@@ -495,6 +495,43 @@ PLYPresentationView(request: request);
 
 ---
 
+## Apple commitment plans (iOS 26.4+) — new in v6
+
+v6 surfaces Apple's "monthly subscription with N-month commitment" (installment)
+billing. **This is Apple-only**: on Android and other platforms the fields below
+are always empty / null, so guard on them before use.
+
+- `PLYPlan.commitmentInfo` — `List<PLYCommitmentInfo>` (empty when the plan has
+  no commitment). Populated wherever a plan is exposed: `allProducts`,
+  `planWithIdentifier`, the `purchase` interceptor payload, and the presentation
+  outcome plan. Each `PLYCommitmentInfo` carries:
+  `billingPlanType` (`PLYBillingPlanType`: `unspecified` / `upFront` / `monthly`),
+  `billingPrice` (`double?`), `billingPeriod` (ISO 8601 duration, e.g. `"P1M"`),
+  `totalPrice` (`double?`), `totalPeriod` (e.g. `"P1Y"`), `totalDuration` (`int?`,
+  number of billing cycles).
+- `PLYSubscription.commitmentProgress` — `PLYCommitmentProgress?` on
+  `userSubscriptions` / `userSubscriptionsHistory` results:
+  `billingPeriodNumber` (`int?`), `totalBillingPeriods` (`int?`),
+  `commitmentExpiresDate` (ISO 8601 `String?`), `commitmentPrice` (`double?`).
+- `PLYDynamicOffering` gains an optional `billingPlanType`
+  (`PLYBillingPlanType`, defaults to `unspecified`) to force a commitment plan
+  type when calling `setDynamicOffering`.
+
+```dart
+final plan = await Purchasely.planWithIdentifier('my_plan');
+for (final c in plan?.commitmentInfo ?? const []) {
+  print('${c.billingPlanType}: ${c.billingPrice} every ${c.billingPeriod}, '
+      'total ${c.totalPrice} over ${c.totalDuration} cycles');
+}
+
+// Force the monthly-commitment variant of a plan in a placement:
+await Purchasely.setDynamicOffering(
+  PLYDynamicOffering('ref', 'my_plan', null, PLYBillingPlanType.monthly),
+);
+```
+
+---
+
 ## What's unchanged
 
 Only the **paywall surface** (start, display / preload / close / back, and the

--- a/purchasely/ios/purchasely_flutter/Classes/PLYPlan+ToMap.swift
+++ b/purchasely/ios/purchasely_flutter/Classes/PLYPlan+ToMap.swift
@@ -69,7 +69,40 @@ extension PLYPlan {
         if let introPeriod = self.localizedIntroductoryPeriod(language: nil) {
             result["introPeriod"] = introPeriod
         }
-        
+
+        // Apple commitment installment details (iOS 26.4+ "monthly subscription
+        // with N-month commitment"). Empty on non-Apple stores / older iOS.
+        if !self.commitmentInfo.isEmpty {
+            result["commitmentInfo"] = self.commitmentInfoMaps
+        }
+
         return result
+    }
+
+    /// Serializes `commitmentInfo` into the same wire shape the Dart
+    /// `plyCommitmentInfoFromMap` parses. Reused by the interceptor payload.
+    var commitmentInfoMaps: [[String: Any]] {
+        self.commitmentInfo.map { info in
+            [
+                "billingPlanType": info.billingPlanType.wireValue,
+                "billingPrice": info.billingPrice.doubleValue,
+                "billingPeriod": info.billingPeriod,
+                "totalPrice": info.totalPrice.doubleValue,
+                "totalPeriod": info.totalPeriod,
+                "totalDuration": info.totalDuration,
+            ]
+        }
+    }
+}
+
+extension PLYBillingPlanType {
+    /// Wire value sent to the Dart bridge, matching the native SDK's own
+    /// string form (`"up_front"` / `"monthly"`).
+    var wireValue: String {
+        switch self {
+        case .upFront: return "up_front"
+        case .monthly: return "monthly"
+        default:       return "unspecified"
+        }
     }
 }

--- a/purchasely/ios/purchasely_flutter/Classes/PLYSubscription+ToMap.swift
+++ b/purchasely/ios/purchasely_flutter/Classes/PLYSubscription+ToMap.swift
@@ -26,7 +26,17 @@ extension PLYSubscription {
         if let date = cancelledDate {
             result["cancelledDate"] = dateFormat.string(from:date)
         }
-        
+
+        // Apple monthly-commitment progress (iOS 26.4+). Nil on non-Apple / older iOS.
+        if let progress = commitmentProgress {
+            result["commitmentProgress"] = [
+                "billingPeriodNumber": progress.billingPeriodNumber,
+                "totalBillingPeriods": progress.totalBillingPeriods,
+                "commitmentExpiresDate": dateFormat.string(from: progress.commitmentExpiresDate),
+                "commitmentPrice": progress.commitmentPrice.doubleValue,
+            ]
+        }
+
         return result
     }
 }

--- a/purchasely/ios/purchasely_flutter/Classes/SwiftPurchaselyFlutterPlugin.swift
+++ b/purchasely/ios/purchasely_flutter/Classes/SwiftPurchaselyFlutterPlugin.swift
@@ -746,10 +746,16 @@ public class SwiftPurchaselyFlutterPlugin: NSObject, FlutterPlugin {
         if let url = params.url?.absoluteString { map["url"] = url }
         if let title = params.title { map["title"] = title }
         if let plan = params.plan {
-            map["plan"] = [
+            var planMap: [String: Any] = [
                 "vendorId": plan.vendorId as Any,
                 "productId": plan.appleProductId as Any?,
             ]
+            // Apple commitment installment details (iOS 26.4+), same wire shape
+            // as PLYPlan.toMap so the Dart payload parses a fully-typed plan.
+            if !plan.commitmentInfo.isEmpty {
+                planMap["commitmentInfo"] = plan.commitmentInfoMaps
+            }
+            map["plan"] = planMap
         }
         // Promotional offer attached to the tapped plan (`offer` on the wire,
         // matching Android's shape). iOS has no `subscriptionOffer` equivalent —
@@ -1353,11 +1359,22 @@ public class SwiftPurchaselyFlutterPlugin: NSObject, FlutterPlugin {
         }
 
         let offerVendorId = arguments["offerVendorId"] as? String
+        let billingPlanType = Self.billingPlanType(fromWire: arguments["billingPlanType"] as? String)
 
         DispatchQueue.main.async {
-            Purchasely.setDynamicOffering(reference: reference, planVendorId: planVendorId, offerVendorId: offerVendorId, completion: { success in
+            Purchasely.setDynamicOffering(reference: reference, planVendorId: planVendorId, offerVendorId: offerVendorId, billingPlanType: billingPlanType, completion: { success in
                 result(success)
             })
+        }
+    }
+
+    /// Maps the Dart `billingPlanType` wire string to the native enum. Unknown
+    /// / nil (Apple-only feature) falls back to `.unspecified`.
+    private static func billingPlanType(fromWire wire: String?) -> PLYBillingPlanType {
+        switch wire {
+        case "up_front": return .upFront
+        case "monthly":  return .monthly
+        default:         return .unspecified
         }
     }
 
@@ -1372,6 +1389,7 @@ public class SwiftPurchaselyFlutterPlugin: NSObject, FlutterPlugin {
 
                     map["reference"] = offering.reference
                     map["planVendorId"] = offering.planId
+                    map["billingPlanType"] = offering.billingPlanType.wireValue
 
                     if let offerId = offering.offerId {
                         map["offerVendorId"] = offerId

--- a/purchasely/lib/purchasely_flutter.dart
+++ b/purchasely/lib/purchasely_flutter.dart
@@ -373,7 +373,9 @@ class Purchasely {
           null,
           null,
           null,
-          null));
+          null)
+        ..commitmentProgress =
+            plyCommitmentProgressFromMap(element['commitmentProgress']));
     });
     return subscriptions;
   }
@@ -413,7 +415,8 @@ class Purchasely {
         element['subscriptionDurationInDays'],
         element['subscriptionDurationInWeeks'],
         element['subscriptionDurationInMonths'],
-      ));
+      )..commitmentProgress =
+          plyCommitmentProgressFromMap(element['commitmentProgress']));
     });
     return subscriptions;
   }
@@ -712,7 +715,8 @@ class Purchasely {
     return await _channel.invokeMethod('setDynamicOffering', <String, dynamic>{
       'reference': offering.reference,
       'planVendorId': offering.planVendorId,
-      'offerVendorId': offering.offerVendorId
+      'offerVendorId': offering.offerVendorId,
+      'billingPlanType': offering.billingPlanType.wire
     });
   }
 
@@ -775,7 +779,10 @@ class Purchasely {
       }
 
       dynamicOfferings.add(PLYDynamicOffering(
-          reference, planVendorId, offering['offerVendorId']));
+          reference,
+          planVendorId,
+          offering['offerVendorId'],
+          plyBillingPlanTypeFromWire(offering['billingPlanType'])));
     });
     return dynamicOfferings;
   }
@@ -1081,6 +1088,10 @@ class PLYSubscription {
   int? subscriptionDurationInWeeks = null;
   int? subscriptionDurationInMonths = null;
 
+  /// Apple monthly-commitment progress (iOS 26.4+). Null on Android and other
+  /// platforms — Apple-only.
+  PLYCommitmentProgress? commitmentProgress;
+
   PLYSubscription(
       this.purchaseToken,
       this.subscriptionSource,
@@ -1238,16 +1249,22 @@ class PLYDynamicOffering {
   String planVendorId;
   String? offerVendorId;
 
-  PLYDynamicOffering(this.reference, this.planVendorId, this.offerVendorId);
+  /// Apple billing plan type to force for this offering (iOS 26.4+). Ignored on
+  /// Android and other platforms. Defaults to [PLYBillingPlanType.unspecified].
+  PLYBillingPlanType billingPlanType;
+
+  PLYDynamicOffering(this.reference, this.planVendorId, this.offerVendorId,
+      [this.billingPlanType = PLYBillingPlanType.unspecified]);
 
   Map<String, dynamic> toJson() => {
         'reference': reference,
         'planVendorId': planVendorId,
         'offerVendorId': offerVendorId,
+        'billingPlanType': billingPlanType.wire,
       };
 
   @override
   String toString() {
-    return 'PLYDynamicOffering(reference: $reference, planVendorId: $planVendorId, offerVendorId: $offerVendorId)';
+    return 'PLYDynamicOffering(reference: $reference, planVendorId: $planVendorId, offerVendorId: $offerVendorId, billingPlanType: $billingPlanType)';
   }
 }

--- a/purchasely/lib/src/ply_models.dart
+++ b/purchasely/lib/src/ply_models.dart
@@ -117,26 +117,6 @@ class PLYSubscriptionOffer {
 /// platforms always report [PLYBillingPlanType.unspecified].
 enum PLYBillingPlanType { unspecified, upFront, monthly }
 
-/// Tolerantly maps the wire `billingPlanType` to [PLYBillingPlanType]. Accepts
-/// the native string form (`"up_front"` / `"monthly"`) and, defensively, the
-/// legacy Int rawValue (0/1/2). Unknown / null falls back to unspecified.
-PLYBillingPlanType plyBillingPlanTypeFromWire(dynamic raw) {
-  if (raw is int && raw >= 0 && raw < PLYBillingPlanType.values.length) {
-    return PLYBillingPlanType.values[raw];
-  }
-  if (raw is String) {
-    switch (raw) {
-      case 'up_front':
-        return PLYBillingPlanType.upFront;
-      case 'monthly':
-        return PLYBillingPlanType.monthly;
-      default:
-        return PLYBillingPlanType.unspecified;
-    }
-  }
-  return PLYBillingPlanType.unspecified;
-}
-
 extension PLYBillingPlanTypeWire on PLYBillingPlanType {
   /// Wire value sent to the native bridge, matching the iOS SDK's wire form.
   String get wire {
@@ -181,16 +161,6 @@ class PLYCommitmentInfo {
     this.totalDuration,
   });
 
-  factory PLYCommitmentInfo.fromJson(Map<dynamic, dynamic> json) =>
-      PLYCommitmentInfo(
-        billingPlanType: plyBillingPlanTypeFromWire(json['billingPlanType']),
-        billingPrice: _toDouble(json['billingPrice']),
-        billingPeriod: json['billingPeriod'] as String?,
-        totalPrice: _toDouble(json['totalPrice']),
-        totalPeriod: json['totalPeriod'] as String?,
-        totalDuration: _toInt(json['totalDuration']),
-      );
-
   @override
   String toString() => 'PLYCommitmentInfo('
       'billingPlanType: $billingPlanType, '
@@ -223,14 +193,6 @@ class PLYCommitmentProgress {
     this.commitmentPrice,
   });
 
-  factory PLYCommitmentProgress.fromJson(Map<dynamic, dynamic> json) =>
-      PLYCommitmentProgress(
-        billingPeriodNumber: _toInt(json['billingPeriodNumber']),
-        totalBillingPeriods: _toInt(json['totalBillingPeriods']),
-        commitmentExpiresDate: json['commitmentExpiresDate'] as String?,
-        commitmentPrice: _toDouble(json['commitmentPrice']),
-      );
-
   @override
   String toString() => 'PLYCommitmentProgress('
       'billingPeriodNumber: $billingPeriodNumber, '
@@ -238,6 +200,3 @@ class PLYCommitmentProgress {
       'commitmentExpiresDate: $commitmentExpiresDate, '
       'commitmentPrice: $commitmentPrice)';
 }
-
-double? _toDouble(dynamic v) => v is num ? v.toDouble() : null;
-int? _toInt(dynamic v) => v is num ? v.toInt() : null;

--- a/purchasely/lib/src/ply_models.dart
+++ b/purchasely/lib/src/ply_models.dart
@@ -33,6 +33,10 @@ class PLYPlan {
   String? offerDuration;
   String? offerPeriod;
 
+  /// Apple commitment installment details (iOS 26.4+ "monthly subscription with
+  /// N-month commitment"). Empty on Android and other platforms — Apple-only.
+  List<PLYCommitmentInfo> commitmentInfo = [];
+
   PLYPlan(
       this.vendorId,
       this.productId,
@@ -108,3 +112,132 @@ class PLYSubscriptionOffer {
   PLYSubscriptionOffer(
       this.subscriptionId, this.basePlanId, this.offerToken, this.offerId);
 }
+
+/// Apple billing plan type for a commitment (iOS 26.4+). Apple-only; other
+/// platforms always report [PLYBillingPlanType.unspecified].
+enum PLYBillingPlanType { unspecified, upFront, monthly }
+
+/// Tolerantly maps the wire `billingPlanType` to [PLYBillingPlanType]. Accepts
+/// the native string form (`"up_front"` / `"monthly"`) and, defensively, the
+/// legacy Int rawValue (0/1/2). Unknown / null falls back to unspecified.
+PLYBillingPlanType plyBillingPlanTypeFromWire(dynamic raw) {
+  if (raw is int && raw >= 0 && raw < PLYBillingPlanType.values.length) {
+    return PLYBillingPlanType.values[raw];
+  }
+  if (raw is String) {
+    switch (raw) {
+      case 'up_front':
+        return PLYBillingPlanType.upFront;
+      case 'monthly':
+        return PLYBillingPlanType.monthly;
+      default:
+        return PLYBillingPlanType.unspecified;
+    }
+  }
+  return PLYBillingPlanType.unspecified;
+}
+
+extension PLYBillingPlanTypeWire on PLYBillingPlanType {
+  /// Wire value sent to the native bridge, matching the iOS SDK's wire form.
+  String get wire {
+    switch (this) {
+      case PLYBillingPlanType.upFront:
+        return 'up_front';
+      case PLYBillingPlanType.monthly:
+        return 'monthly';
+      case PLYBillingPlanType.unspecified:
+        return 'unspecified';
+    }
+  }
+}
+
+/// Commitment installment details for an Apple "monthly subscription with
+/// N-month commitment" plan (iOS 26.4+). Apple-only.
+class PLYCommitmentInfo {
+  final PLYBillingPlanType billingPlanType;
+
+  /// Per-billing-cycle price (e.g. 9.99 for a monthly-billed plan).
+  final double? billingPrice;
+
+  /// ISO 8601 duration of each billing cycle, e.g. "P1M".
+  final String? billingPeriod;
+
+  /// Total price over the full commitment (e.g. 119.88 for 12 × 9.99).
+  final double? totalPrice;
+
+  /// ISO 8601 duration of the full commitment, e.g. "P1Y".
+  final String? totalPeriod;
+
+  /// Number of billing cycles in the commitment (1 for up-front, 12 for a
+  /// 12-month monthly commitment).
+  final int? totalDuration;
+
+  PLYCommitmentInfo({
+    required this.billingPlanType,
+    this.billingPrice,
+    this.billingPeriod,
+    this.totalPrice,
+    this.totalPeriod,
+    this.totalDuration,
+  });
+
+  factory PLYCommitmentInfo.fromJson(Map<dynamic, dynamic> json) =>
+      PLYCommitmentInfo(
+        billingPlanType: plyBillingPlanTypeFromWire(json['billingPlanType']),
+        billingPrice: _toDouble(json['billingPrice']),
+        billingPeriod: json['billingPeriod'] as String?,
+        totalPrice: _toDouble(json['totalPrice']),
+        totalPeriod: json['totalPeriod'] as String?,
+        totalDuration: _toInt(json['totalDuration']),
+      );
+
+  @override
+  String toString() => 'PLYCommitmentInfo('
+      'billingPlanType: $billingPlanType, '
+      'billingPrice: $billingPrice, '
+      'billingPeriod: $billingPeriod, '
+      'totalPrice: $totalPrice, '
+      'totalPeriod: $totalPeriod, '
+      'totalDuration: $totalDuration)';
+}
+
+/// A subscriber's progress through an Apple monthly-commitment plan
+/// (iOS 26.4+). Null on Android and other platforms — Apple-only.
+class PLYCommitmentProgress {
+  /// The current billing period number within the commitment (1-based).
+  final int? billingPeriodNumber;
+
+  /// The total number of billing periods in the commitment.
+  final int? totalBillingPeriods;
+
+  /// ISO 8601 date at which the commitment expires.
+  final String? commitmentExpiresDate;
+
+  /// The price charged for this billing period.
+  final double? commitmentPrice;
+
+  PLYCommitmentProgress({
+    this.billingPeriodNumber,
+    this.totalBillingPeriods,
+    this.commitmentExpiresDate,
+    this.commitmentPrice,
+  });
+
+  factory PLYCommitmentProgress.fromJson(Map<dynamic, dynamic> json) =>
+      PLYCommitmentProgress(
+        billingPeriodNumber: _toInt(json['billingPeriodNumber']),
+        totalBillingPeriods: _toInt(json['totalBillingPeriods']),
+        commitmentExpiresDate: json['commitmentExpiresDate'] as String?,
+        commitmentPrice: _toDouble(json['commitmentPrice']),
+      );
+
+  @override
+  String toString() => 'PLYCommitmentProgress('
+      'billingPeriodNumber: $billingPeriodNumber, '
+      'totalBillingPeriods: $totalBillingPeriods, '
+      'commitmentExpiresDate: $commitmentExpiresDate, '
+      'commitmentPrice: $commitmentPrice)';
+}
+
+double? _toDouble(dynamic v) => v is num ? v.toDouble() : null;
+int? _toInt(dynamic v) => v is num ? v.toInt() : null;

--- a/purchasely/lib/src/ply_transformers.dart
+++ b/purchasely/lib/src/ply_transformers.dart
@@ -34,7 +34,24 @@ PLYPlan? plyPlanFromMap(Map<dynamic, dynamic>? plan) {
     offerDuration,
     offerPeriod,
     plan['basePlanId'],
-  );
+  )..commitmentInfo = plyCommitmentInfoFromMap(plan['commitmentInfo']);
+}
+
+/// Parses the Apple commitment installment array (iOS 26.4+). Returns an empty
+/// list when absent (Android and other platforms never send it).
+List<PLYCommitmentInfo> plyCommitmentInfoFromMap(dynamic raw) {
+  if (raw is! List) return const [];
+  return raw
+      .whereType<Map>()
+      .map((e) => PLYCommitmentInfo.fromJson(e))
+      .toList();
+}
+
+/// Parses the Apple commitment progress object (iOS 26.4+). Returns null when
+/// absent (Android and other platforms never send it).
+PLYCommitmentProgress? plyCommitmentProgressFromMap(dynamic raw) {
+  if (raw is! Map || raw.isEmpty) return null;
+  return PLYCommitmentProgress.fromJson(raw);
 }
 
 PLYPlanType plyPlanTypeFromWire(dynamic rawType) {

--- a/purchasely/lib/src/ply_transformers.dart
+++ b/purchasely/lib/src/ply_transformers.dart
@@ -40,18 +40,30 @@ PLYPlan? plyPlanFromMap(Map<dynamic, dynamic>? plan) {
 /// Parses the Apple commitment installment array (iOS 26.4+). Returns an empty
 /// list when absent (Android and other platforms never send it).
 List<PLYCommitmentInfo> plyCommitmentInfoFromMap(dynamic raw) {
-  if (raw is! List) return const [];
-  return raw
-      .whereType<Map>()
-      .map((e) => PLYCommitmentInfo.fromJson(e))
-      .toList();
+  if (raw is! List) return [];
+  return raw.whereType<Map>().map(_commitmentInfoFromJson).toList();
 }
+
+PLYCommitmentInfo _commitmentInfoFromJson(Map<dynamic, dynamic> json) =>
+    PLYCommitmentInfo(
+      billingPlanType: plyBillingPlanTypeFromWire(json['billingPlanType']),
+      billingPrice: _toDouble(json['billingPrice']),
+      billingPeriod: json['billingPeriod'] as String?,
+      totalPrice: _toDouble(json['totalPrice']),
+      totalPeriod: json['totalPeriod'] as String?,
+      totalDuration: _toInt(json['totalDuration']),
+    );
 
 /// Parses the Apple commitment progress object (iOS 26.4+). Returns null when
 /// absent (Android and other platforms never send it).
 PLYCommitmentProgress? plyCommitmentProgressFromMap(dynamic raw) {
   if (raw is! Map || raw.isEmpty) return null;
-  return PLYCommitmentProgress.fromJson(raw);
+  return PLYCommitmentProgress(
+    billingPeriodNumber: _toInt(raw['billingPeriodNumber']),
+    totalBillingPeriods: _toInt(raw['totalBillingPeriods']),
+    commitmentExpiresDate: raw['commitmentExpiresDate'] as String?,
+    commitmentPrice: _toDouble(raw['commitmentPrice']),
+  );
 }
 
 PLYPlanType plyPlanTypeFromWire(dynamic rawType) {
@@ -73,6 +85,26 @@ PLYPlanType plyPlanTypeFromWire(dynamic rawType) {
     }
   }
   return PLYPlanType.unknown;
+}
+
+/// Tolerantly maps the wire `billingPlanType` to [PLYBillingPlanType]. Accepts
+/// the native string form (`"up_front"` / `"monthly"`) and, defensively, the
+/// legacy Int rawValue (0/1/2). Unknown / null falls back to unspecified.
+PLYBillingPlanType plyBillingPlanTypeFromWire(dynamic raw) {
+  if (raw is int && raw >= 0 && raw < PLYBillingPlanType.values.length) {
+    return PLYBillingPlanType.values[raw];
+  }
+  if (raw is String) {
+    switch (raw) {
+      case 'up_front':
+        return PLYBillingPlanType.upFront;
+      case 'monthly':
+        return PLYBillingPlanType.monthly;
+      default:
+        return PLYBillingPlanType.unspecified;
+    }
+  }
+  return PLYBillingPlanType.unspecified;
 }
 
 PLYPromoOffer? plyPromoOfferFromMap(Map<dynamic, dynamic>? offer) {
@@ -107,3 +139,5 @@ double? _toDouble(dynamic value) {
   if (value is num) return value.toDouble();
   return null;
 }
+
+int? _toInt(dynamic value) => value is num ? value.toInt() : null;

--- a/purchasely/test/commitment_test.dart
+++ b/purchasely/test/commitment_test.dart
@@ -1,0 +1,139 @@
+// Unit tests for the Apple commitment bridge mapping (iOS 26.4+ "monthly
+// subscription with N-month commitment"). Covers:
+//   - PLYPlan.commitmentInfo parsing (via the public purchase interceptor path
+//     and directly via plyPlanFromMap),
+//   - PLYCommitmentProgress parsing on a subscription,
+//   - PLYBillingPlanType wire mapping (string, legacy int, unknown/null),
+//   - Apple-only null/empty behaviour (Android/other platforms send nothing).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:purchasely_flutter/purchasely_flutter.dart';
+// Transformers are not part of the public barrel — import src/ directly.
+import 'package:purchasely_flutter/src/ply_transformers.dart';
+
+void main() {
+  group('PLYBillingPlanType wire mapping', () {
+    test('string wire values map to cases', () {
+      expect(
+          plyBillingPlanTypeFromWire('up_front'), PLYBillingPlanType.upFront);
+      expect(plyBillingPlanTypeFromWire('monthly'), PLYBillingPlanType.monthly);
+      expect(plyBillingPlanTypeFromWire('unspecified'),
+          PLYBillingPlanType.unspecified);
+    });
+
+    test('legacy int rawValue maps to cases', () {
+      expect(plyBillingPlanTypeFromWire(0), PLYBillingPlanType.unspecified);
+      expect(plyBillingPlanTypeFromWire(1), PLYBillingPlanType.upFront);
+      expect(plyBillingPlanTypeFromWire(2), PLYBillingPlanType.monthly);
+    });
+
+    test('unknown / null / out-of-range falls back to unspecified', () {
+      expect(plyBillingPlanTypeFromWire(null), PLYBillingPlanType.unspecified);
+      expect(
+          plyBillingPlanTypeFromWire('nope'), PLYBillingPlanType.unspecified);
+      expect(plyBillingPlanTypeFromWire(99), PLYBillingPlanType.unspecified);
+    });
+
+    test('wire round-trips through the extension', () {
+      expect(PLYBillingPlanType.upFront.wire, 'up_front');
+      expect(PLYBillingPlanType.monthly.wire, 'monthly');
+      expect(PLYBillingPlanType.unspecified.wire, 'unspecified');
+    });
+  });
+
+  group('plyPlanFromMap commitmentInfo', () {
+    test('parses a monthly commitment installment array', () {
+      final plan = plyPlanFromMap({
+        'vendorId': 'plan_x',
+        'type': 2,
+        'commitmentInfo': [
+          {
+            'billingPlanType': 'monthly',
+            'billingPrice': 9.99,
+            'billingPeriod': 'P1M',
+            'totalPrice': 119.88,
+            'totalPeriod': 'P1Y',
+            'totalDuration': 12,
+          },
+        ],
+      });
+
+      expect(plan, isNotNull);
+      expect(plan!.commitmentInfo, hasLength(1));
+      final info = plan.commitmentInfo.first;
+      expect(info.billingPlanType, PLYBillingPlanType.monthly);
+      expect(info.billingPrice, 9.99);
+      expect(info.billingPeriod, 'P1M');
+      expect(info.totalPrice, 119.88);
+      expect(info.totalPeriod, 'P1Y');
+      expect(info.totalDuration, 12);
+    });
+
+    test('absent commitmentInfo (Android/other) yields an empty list', () {
+      final plan = plyPlanFromMap({'vendorId': 'plan_x', 'type': 2});
+      expect(plan, isNotNull);
+      expect(plan!.commitmentInfo, isEmpty);
+    });
+
+    test('exposed through the purchase interceptor payload', () {
+      final payload = actionPayloadFromMap(
+        PLYPresentationActionKind.purchase,
+        {
+          'plan': {
+            'vendorId': 'plan_x',
+            'type': 2,
+            'commitmentInfo': [
+              {
+                'billingPlanType': 'up_front',
+                'billingPrice': 119.88,
+                'billingPeriod': 'P1Y',
+                'totalPrice': 119.88,
+                'totalPeriod': 'P1Y',
+                'totalDuration': 1,
+              },
+            ],
+          },
+        },
+      ) as PLYPurchasePayload;
+
+      expect(payload.plan.commitmentInfo, hasLength(1));
+      expect(payload.plan.commitmentInfo.first.billingPlanType,
+          PLYBillingPlanType.upFront);
+      expect(payload.plan.commitmentInfo.first.totalDuration, 1);
+    });
+  });
+
+  group('plyCommitmentProgressFromMap', () {
+    test('parses billing progress with an ISO 8601 expiry date', () {
+      final progress = plyCommitmentProgressFromMap({
+        'billingPeriodNumber': 3,
+        'totalBillingPeriods': 12,
+        'commitmentExpiresDate': '2027-01-15T00:00:00+0000',
+        'commitmentPrice': 9.99,
+      });
+
+      expect(progress, isNotNull);
+      expect(progress!.billingPeriodNumber, 3);
+      expect(progress.totalBillingPeriods, 12);
+      expect(progress.commitmentExpiresDate, '2027-01-15T00:00:00+0000');
+      expect(progress.commitmentPrice, 9.99);
+    });
+
+    test('null / empty map (Android/other) yields null', () {
+      expect(plyCommitmentProgressFromMap(null), isNull);
+      expect(plyCommitmentProgressFromMap(const {}), isNull);
+    });
+  });
+
+  group('PLYDynamicOffering billingPlanType', () {
+    test('defaults to unspecified and serializes the wire value', () {
+      final offering = PLYDynamicOffering('ref', 'plan_x', null);
+      expect(offering.billingPlanType, PLYBillingPlanType.unspecified);
+      expect(offering.toJson()['billingPlanType'], 'unspecified');
+
+      final monthly =
+          PLYDynamicOffering('ref', 'plan_x', null, PLYBillingPlanType.monthly);
+      expect(monthly.toJson()['billingPlanType'], 'monthly');
+    });
+  });
+}


### PR DESCRIPTION
## Contexte

Le SDK iOS natif Purchasely v6 (pod `6.0.0-rc.3`) expose le support Apple « monthly subscription with 12-month commitment » (facturation par échéances, iOS 26.4+) via une API publique. Les bridges cross-platform ne l'exposaient pas encore. Cette PR comble le trou de parité **côté Flutter uniquement**.

Fonctionnalité **Apple-only** : sur Android et les autres plateformes, les champs restent vides / null (parsing null-safe garanti).

## Contrat iOS vérifié

API présente et confirmée sur le pod épinglé `Purchasely 6.0.0-rc.3` — vérifié à la fois sur le tag git et sur le binaire réellement distribué en cache CocoaPods (`arm64-apple-ios.swiftinterface`, checksum `ffb024…48` = celui du `Podfile.lock`) :
- `PLYPlan.commitmentInfo: [PLYCommitmentInfo]`
- `PLYSubscription.commitmentProgress: PLYCommitmentProgress?`
- `PLYCommitmentInfo` (billingPlanType, billingPrice, billingPeriod, totalPrice, totalPeriod, totalDuration)
- `PLYCommitmentProgress` (billingPeriodNumber, totalBillingPeriods, commitmentExpiresDate, commitmentPrice)
- `PLYBillingPlanType` (unspecified / upFront / monthly), `PLYOffering.billingPlanType`, `setDynamicOffering(…, billingPlanType:)`

## Fichiers modifiés

**Dart**
- `purchasely/lib/src/ply_models.dart` — enum `PLYBillingPlanType` + helper `plyBillingPlanTypeFromWire` (tolère string ET int legacy) + extension `.wire` ; classes `PLYCommitmentInfo` / `PLYCommitmentProgress` (avec `fromJson`) ; champ `commitmentInfo` sur `PLYPlan`.
- `purchasely/lib/src/ply_transformers.dart` — `plyCommitmentInfoFromMap` / `plyCommitmentProgressFromMap` ; `plyPlanFromMap` peuple `commitmentInfo`.
- `purchasely/lib/purchasely_flutter.dart` — champ `commitmentProgress` sur `PLYSubscription` (peuplé dans `userSubscriptions` + `userSubscriptionsHistory`) ; `PLYDynamicOffering` gagne `billingPlanType` (propagé à `setDynamicOffering`, reparsé depuis `getDynamicOfferings`).

**iOS (bridge Swift, calqué sur les patterns existants)**
- `purchasely/ios/purchasely_flutter/Classes/PLYPlan+ToMap.swift` — clé `commitmentInfo` (via `commitmentInfoMaps` réutilisable) + extension `PLYBillingPlanType.wireValue`.
- `purchasely/ios/purchasely_flutter/Classes/PLYSubscription+ToMap.swift` — clé `commitmentProgress` (date en ISO 8601).
- `purchasely/ios/purchasely_flutter/Classes/SwiftPurchaselyFlutterPlugin.swift` — `commitmentInfo` dans le plan du payload purchase de l'interceptor ; `setDynamicOffering` passe `billingPlanType` au natif ; `getDynamicOfferings` sérialise `billingPlanType`.

**Docs**
- `MIGRATION-v6.md` — nouvelle section « Apple commitment plans (iOS 26.4+) ».

**Android** : aucun changement. Vérifié que le plugin Kotlin lit ses arguments par clé et ignore les clés extra → parsing null-safe côté Dart.

## Forme exacte des payloads

Plan (clé `commitmentInfo`, tableau) :
```json
{"billingPlanType":"monthly","billingPrice":9.99,"billingPeriod":"P1M","totalPrice":119.88,"totalPeriod":"P1Y","totalDuration":12}
```

Subscription (clé `commitmentProgress`) :
```json
{"billingPeriodNumber":3,"totalBillingPeriods":12,"commitmentExpiresDate":"2027-01-15T00:00:00+0000","commitmentPrice":9.99}
```

Dynamic offering : clé `billingPlanType` = `"up_front"` / `"monthly"` / `"unspecified"` (string).

## Convention wire billingPlanType

Le wire de `billingPlanType` est une **string snake_case** (`"up_front"` / `"monthly"` / `"unspecified"`), alignée sur la forme interne du SDK natif iOS. C'est **intentionnel et non uniformisé cross-bridge** (chaque bridge garde sa convention wire) ; le parsing Dart tolère aussi l'int rawValue par robustesse.

## Résultats

- **`flutter test`** : 308 tests, 0 échec (dont 10 nouveaux dans `test/commitment_test.dart`).
- **`flutter analyze`** : No issues found.
- **`dart format --set-exit-if-changed .`** : clean.
- **Build iOS local** : `flutter build ios --simulator --no-codesign` → exit 0, `Runner.app` construit. Compilé contre le pod `Purchasely 6.0.0-rc.3` ; les 3 fichiers Swift modifiés produisent bien leurs `.o` (arm64 + x86_64). Preuve que le mapping Swift compile contre l'API du pod.

## Note CI iOS

La CI (`ci.yml`) **couvre bien iOS** : jobs `ios-unit-tests` (xcodebuild test RunnerTests), `build-ios` (`flutter build ios --debug --simulator --no-codesign`), `build-ios-swiftpm` (build SwiftPM) et `validate-podspec` (`pod lib lint`), tous gated par `ci-success`.

**Attention** : `ci.yml` (et `e2e-ios.yml`) ne se déclenchent que sur les PR ciblant `main` / `master` / `develop`. **Cette PR cible `feat/sdk-v6-migration`, donc la CI ne tournera PAS automatiquement dessus.** La couverture iOS s'appliquera lorsque `feat/sdk-v6-migration` sera mergée vers `main`. (Signalé, non modifié.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
